### PR TITLE
Fix crate dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,10 +46,10 @@ panic-probe = { version = "0.3.0", features = ["print-defmt"] }
 # If you're not going to use a Board Support Package you'll need these:
 # rp2040-hal = { git = "https://github.com/rp-rs/rp-hal", branch="main", features=["rt", "critical-section-impl", "disable-intrinsics", "rtic-monotonic"] }
 # rp2040-hal = { version = "0.8.0", features=["rt", "critical-section-impl"] }
-rp2040-boot2 = { git = "https://github.com/rp-rs/rp2040-boot2-rs", branch="main" }
+rp2040-boot2 = "0.3"
 st7735-lcd = "0.8"
 embedded-sdmmc = { git = "https://github.com/UserJHansen/embedded-sdmmc-rs/", branch="develop", optional = true }
-shared-bus = { version = "0.2.5", features=["cortex-m"] }
+shared-bus = { version = "0.3.1", features=["cortex-m"] }
 fugit = "0.3.6"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
@@ -75,9 +75,6 @@ features = [
   'Window',
   'Storage'
 ]
-
-[patch.crates-io]
-embedded-graphics = { git = "https://github.com/embedded-graphics/embedded-graphics.git" }
 
 # cargo build/run
 [profile.dev]


### PR DESCRIPTION
Currently, trowel does not compile because of outdated dependencies.